### PR TITLE
Add block-wise LFN analysis

### DIFF
--- a/Mute-Voce-main/LFN_Docker_Toolkit_Extended/LFN_Docker_Toolkit_Extended/lfn_batch_file_analyzer.py
+++ b/Mute-Voce-main/LFN_Docker_Toolkit_Extended/LFN_Docker_Toolkit_Extended/lfn_batch_file_analyzer.py
@@ -19,31 +19,80 @@ def convert_to_wav(input_path, output_path):
     command = ["ffmpeg", "-y", "-i", input_path, "-ar", "44100", "-ac", "1", output_path]
     subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
-def analyze_audio(filepath, label):
-    data, sr = sf.read(filepath)
-    if data.ndim > 1:
-        data = data.mean(axis=1)
+def analyze_audio(filepath, label, block_duration=None):
+    """Analyze a single audio file.
 
-    f, t, Sxx = spectrogram(data, fs=sr, nperseg=4096, noverlap=2048)
-    Sxx_db = 10 * np.log10(Sxx + 1e-10)
+    Parameters
+    ----------
+    filepath : str
+        Path to the audio file.
+    label : str
+        Name used in results.
+    block_duration : float, optional
+        Duration of the blocks in seconds. When provided, the file is processed
+        chunk by chunk which avoids loading the entire recording into memory.
+    """
 
-    lfn_mask = (f >= LF_RANGE[0]) & (f <= LF_RANGE[1])
-    lfn_freqs = f[lfn_mask]
-    lfn_spec = Sxx_db[lfn_mask, :]
-    lfn_peak = lfn_freqs[np.unravel_index(np.argmax(lfn_spec), lfn_spec.shape)[0]]
-    lfn_db = np.max(lfn_spec)
+    with sf.SoundFile(filepath) as f:
+        sr = f.samplerate
+        block_frames = int(sr * block_duration) if block_duration else f.frames
 
-    hf_mask = (f >= HF_RANGE[0]) & (f <= HF_RANGE[1])
-    hf_freqs = f[hf_mask]
-    hf_spec = Sxx_db[hf_mask, :]
-    if hf_freqs.size > 0:
-        hf_peak = hf_freqs[np.unravel_index(np.argmax(hf_spec), hf_spec.shape)[0]]
-        hf_db = np.max(hf_spec)
-    else:
-        hf_peak, hf_db = 0, -100
+        # Variables for tracking peaks across blocks
+        max_lfn_db = -np.inf
+        max_lfn_peak = 0
+        max_hf_db = -np.inf
+        max_hf_peak = 0
 
+        spec_accum = None
+        time_accum = []
+        current_time = 0.0
+
+        for block in f.blocks(blocksize=block_frames, dtype='float32'):
+            if block.ndim > 1:
+                block = block.mean(axis=1)
+
+            freqs, times, Sxx = spectrogram(block, fs=sr, nperseg=4096, noverlap=2048)
+            Sxx_db = 10 * np.log10(Sxx + 1e-10)
+
+            # LFN peak for this block
+            lfn_mask = (freqs >= LF_RANGE[0]) & (freqs <= LF_RANGE[1])
+            lfn_freqs = freqs[lfn_mask]
+            lfn_spec = Sxx_db[lfn_mask, :]
+            if lfn_spec.size:
+                idx = np.argmax(lfn_spec)
+                lfn_db_block = lfn_spec.flat[idx]
+                lfn_peak_block = lfn_freqs[np.unravel_index(idx, lfn_spec.shape)[0]]
+                if lfn_db_block > max_lfn_db:
+                    max_lfn_db = lfn_db_block
+                    max_lfn_peak = lfn_peak_block
+
+            # Ultrasonic peak for this block
+            hf_mask = (freqs >= HF_RANGE[0]) & (freqs <= HF_RANGE[1])
+            hf_freqs = freqs[hf_mask]
+            hf_spec = Sxx_db[hf_mask, :]
+            if hf_freqs.size:
+                idx = np.argmax(hf_spec)
+                hf_db_block = hf_spec.flat[idx]
+                hf_peak_block = hf_freqs[np.unravel_index(idx, hf_spec.shape)[0]]
+                if hf_db_block > max_hf_db:
+                    max_hf_db = hf_db_block
+                    max_hf_peak = hf_peak_block
+
+            # Accumulate spectrogram data up to 500 Hz
+            freq_mask_500 = freqs <= 500
+            spec_slice = Sxx_db[freq_mask_500, :]
+            if spec_accum is None:
+                spec_freqs = freqs[freq_mask_500]
+                spec_accum = spec_slice
+            else:
+                spec_accum = np.hstack((spec_accum, spec_slice))
+
+            time_accum.extend(times + current_time)
+            current_time += len(block) / sr
+
+    # Plot accumulated spectrogram
     plt.figure(figsize=(12, 6))
-    plt.pcolormesh(t, f[f <= 500], Sxx_db[f <= 500, :], shading='gouraud')
+    plt.pcolormesh(time_accum, spec_freqs, spec_accum, shading='gouraud')
     plt.title(f"Spectrogram: {label}")
     plt.ylabel("Frequency (Hz)")
     plt.xlabel("Time (s)")
@@ -55,18 +104,24 @@ def analyze_audio(filepath, label):
 
     return {
         "Filename": label,
-        "LFN Peak (Hz)": round(float(lfn_peak), 2),
-        "LFN dB": round(float(lfn_db), 2),
-        "Ultrasonic Peak (Hz)": round(float(hf_peak), 2),
-        "Ultrasonic dB": round(float(hf_db), 2),
+        "LFN Peak (Hz)": round(float(max_lfn_peak), 2),
+        "LFN dB": round(float(max_lfn_db), 2),
+        "Ultrasonic Peak (Hz)": round(float(max_hf_peak), 2),
+        "Ultrasonic dB": round(float(max_hf_db), 2),
         "Spectrogram": out_img
     }
 
 def main():
-    if len(sys.argv) < 2:
-        print("❌ Please provide the path to the audio directory.")
-        return
-    input_dir = sys.argv[1]
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Batch analyze audio files for LFN and ultrasonic peaks")
+    parser.add_argument("directory", help="Path to the audio directory")
+    parser.add_argument("--block-duration", type=float, default=None,
+                        help="Chunk size in seconds for processing large files")
+    args = parser.parse_args()
+
+    input_dir = args.directory
+    block_duration = args.block_duration
     for file in os.listdir(input_dir):
         ext = file.lower().split('.')[-1]
         if ext in ["wav", "mp3", "mp4"]:
@@ -78,7 +133,7 @@ def main():
                 convert_to_wav(full_path, wav_path)
             print(f"Analyzing {file}...")
             try:
-                result = analyze_audio(wav_path, file)
+                result = analyze_audio(wav_path, file, block_duration=block_duration)
                 results.append(result)
             except Exception as e:
                 print(f"Error analyzing {file}: {e}")

--- a/Mute-Voce-main/README.md
+++ b/Mute-Voce-main/README.md
@@ -1,2 +1,16 @@
 # Muta Voce
 Analyze audio for soft voices—far-field or similar—enhance the signal, perform voice-fingerprinting, and build a catalog of voice prints. Keep detailed logs of every detected voice, recording attributes that aid identification (voice color, formants, idiosyncrasies), plus date and precise timestamps. Provide an enhanced track that makes the voices clearly audible and distinct from background noise that other systems might misclassify due to limited training libraries
+
+## LFN Batch File Analyzer
+
+The script `LFN_Docker_Toolkit_Extended/LFN_Docker_Toolkit_Extended/lfn_batch_file_analyzer.py`
+analyzes audio files for low‑frequency noise (LFN) and ultrasonic peaks.
+
+```
+python lfn_batch_file_analyzer.py <directory> [--block-duration SECONDS]
+```
+
+Use `--block-duration` to set the chunk size when reading files. Processing
+recordings block by block prevents memory errors with very long audio while still
+producing a spectrogram of the entire file (only frequencies up to 500 Hz are
+stored).


### PR DESCRIPTION
## Summary
- support processing audio in chunks in `lfn_batch_file_analyzer.py`
- expose optional `--block-duration` CLI argument
- document usage in README

## Testing
- `python -m py_compile LFN_Docker_Toolkit_Extended/LFN_Docker_Toolkit_Extended/lfn_batch_file_analyzer.py`
- `python LFN_Docker_Toolkit_Extended/LFN_Docker_Toolkit_Extended/lfn_batch_file_analyzer.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686ac48c0c5c8320a8439e968e176e18