### PR TITLE
Make LiveVoiceAutoZoom support any mic

### DIFF
--- a/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/run_zoom.bat
+++ b/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/run_zoom.bat
@@ -1,4 +1,4 @@
 @echo off
 cd /d %~dp0scripts
-python live_zoom_record_and_analyze.py
+python live_zoom_record_and_analyze.py %*
 pause

--- a/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/gui.py
+++ b/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/gui.py
@@ -7,7 +7,7 @@ import time
 import sounddevice as sd
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
-from recorder import record_audio, save_audio, find_zoom_input
+from recorder import record_audio, save_audio, find_input_device
 from vad_enhancer import detect_voiced, enhance_audio
 from speaker_recognition import extract_embedding, load_known_speakers, recognize_speaker
 
@@ -29,7 +29,7 @@ class VoiceRecorderGUI:
 
         self.recording = False
         self.stream = None
-        self.device_index = find_zoom_input()
+        self.device_index = find_input_device()
 
         self.start_button = tk.Button(root, text="Start Recording", command=self.start_recording)
         self.start_button.pack(side=tk.LEFT, padx=20)

--- a/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/recorder.py
+++ b/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/recorder.py
@@ -7,16 +7,38 @@ SAMPLE_RATE = 44100
 CHANNELS = 1
 BIT_DEPTH = 'PCM_16'
 
-def find_zoom_input():
-    for idx, d in enumerate(sd.query_devices()):
-        if "Zoom" in d['name'] and d['max_input_channels'] >= 1:
+def find_input_device(name_substr=None):
+    """Return an input device index.
+
+    Parameters
+    ----------
+    name_substr : str, optional
+        Substring to search for in device names. If provided, the first
+        matching device with input channels is returned.
+    """
+    devices = sd.query_devices()
+
+    if name_substr:
+        for idx, d in enumerate(devices):
+            if name_substr.lower() in d['name'].lower() and d['max_input_channels'] >= 1:
+                return idx
+        raise RuntimeError(f"Input device containing '{name_substr}' not found.")
+
+    default = sd.default.device[0] if sd.default.device else None
+    if default is not None and sd.query_devices(default)['max_input_channels'] > 0:
+        return default
+
+    for idx, d in enumerate(devices):
+        if d['max_input_channels'] >= 1:
             return idx
-    raise RuntimeError("Zoom H6 not found. Connect it and enable Audio Interface mode.")
+
+    raise RuntimeError("No input device with recording channels available.")
 
 def record_audio(duration_sec=10, device_index=None):
-    print(f"[Recording] {duration_sec}s from Zoom H6...")
+    """Record audio from the specified or default input device."""
     if device_index is None:
-        device_index = find_zoom_input()
+        device_index = find_input_device()
+    print(f"[Recording] {duration_sec}s from device {device_index}...")
 
     audio = sd.rec(int(duration_sec * SAMPLE_RATE), samplerate=SAMPLE_RATE,
                    channels=CHANNELS, dtype='int16', device=device_index)

--- a/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/scripts/gui.py
+++ b/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/scripts/gui.py
@@ -7,7 +7,7 @@ import time
 import sounddevice as sd
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
-from recorder import record_audio, save_audio, find_zoom_input
+from recorder import record_audio, save_audio, find_input_device
 from vad_enhancer import detect_voiced, enhance_audio
 from speaker_recognition import extract_embedding, load_known_speakers, recognize_speaker
 
@@ -29,7 +29,7 @@ class VoiceRecorderGUI:
 
         self.recording = False
         self.stream = None
-        self.device_index = find_zoom_input()
+        self.device_index = find_input_device()
 
         self.start_button = tk.Button(root, text="Start Recording", command=self.start_recording)
         self.start_button.pack(side=tk.LEFT, padx=20)

--- a/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/scripts/recorder.py
+++ b/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/scripts/recorder.py
@@ -7,16 +7,38 @@ SAMPLE_RATE = 44100
 CHANNELS = 1
 BIT_DEPTH = 'PCM_16'
 
-def find_zoom_input():
-    for idx, d in enumerate(sd.query_devices()):
-        if "Zoom" in d['name'] and d['max_input_channels'] >= 1:
+def find_input_device(name_substr=None):
+    """Return an input device index.
+
+    Parameters
+    ----------
+    name_substr : str, optional
+        Substring to search for in device names. If provided, the first
+        matching device with input channels is returned.
+    """
+    devices = sd.query_devices()
+
+    if name_substr:
+        for idx, d in enumerate(devices):
+            if name_substr.lower() in d['name'].lower() and d['max_input_channels'] >= 1:
+                return idx
+        raise RuntimeError(f"Input device containing '{name_substr}' not found.")
+
+    default = sd.default.device[0] if sd.default.device else None
+    if default is not None and sd.query_devices(default)['max_input_channels'] > 0:
+        return default
+
+    for idx, d in enumerate(devices):
+        if d['max_input_channels'] >= 1:
             return idx
-    raise RuntimeError("Zoom H6 not found. Connect it and enable Audio Interface mode.")
+
+    raise RuntimeError("No input device with recording channels available.")
 
 def record_audio(duration_sec=10, device_index=None):
-    print(f"[Recording] {duration_sec}s from Zoom H6...")
+    """Record audio from the specified or default input device."""
     if device_index is None:
-        device_index = find_zoom_input()
+        device_index = find_input_device()
+    print(f"[Recording] {duration_sec}s from device {device_index}...")
 
     audio = sd.rec(int(duration_sec * SAMPLE_RATE), samplerate=SAMPLE_RATE,
                    channels=CHANNELS, dtype='int16', device=device_index)

--- a/Mute-Voce-main/README.md
+++ b/Mute-Voce-main/README.md
@@ -36,3 +36,10 @@ python live_zoom_record_and_analyze.py [--device DEVICE] [--duration SECS] [--bl
 * `--device` – input device index or name substring (default: system default)
 * `--duration` – recording length in seconds (default: 4440)
 * `--block-duration` – length of audio chunks written to disk (default: 10)
+
+On Windows, use `run_zoom.bat` to launch the recorder. Any arguments passed to the
+batch file are forwarded to the Python script:
+
+```
+run_zoom.bat --device "USB Microphone"
+```


### PR DESCRIPTION
## Summary
- make recorder find any available microphone and use it by default
- update GUI to grab microphone via new helper
- forward arguments from `run_zoom.bat` to Python script
- document batch file usage in README

## Testing
- `python -m py_compile LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/*.py LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68726ef47e6c8320ba744098dbf59899