### PR TITLE
Add mid-range enhancement and speaker fingerprint breakdown

### DIFF
--- a/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/vad_enhancer.py
+++ b/Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/vad_enhancer.py
@@ -1,7 +1,7 @@
 
 import numpy as np
 import webrtcvad
-import collections
+from scipy.signal import butter, lfilter
 
 SAMPLE_RATE = 44100
 FRAME_DURATION = 30  # ms
@@ -24,11 +24,24 @@ def detect_voiced(audio, sample_rate=SAMPLE_RATE):
             voiced.extend(frame)
     return np.array(voiced, dtype=np.int16)
 
-def enhance_audio(voiced_audio):
+def apply_midrange_enhancement(audio, sample_rate=SAMPLE_RATE, low=300, high=3000, gain=1.5):
+    """Boost mid-range frequencies to improve intelligibility."""
+    nyq = 0.5 * sample_rate
+    low /= nyq
+    high /= nyq
+    b, a = butter(2, [low, high], btype="band")
+    mid = lfilter(b, a, audio)
+    enhanced = audio + gain * mid
+    return np.clip(enhanced, -1.0, 1.0)
+
+
+def enhance_audio(voiced_audio, sample_rate=SAMPLE_RATE):
+    """Normalize, amplify, and boost mid-range frequencies."""
     if len(voiced_audio) == 0:
         return np.zeros(1, dtype=np.float32)
     if voiced_audio.dtype != np.float32:
         voiced_audio = voiced_audio.astype(np.float32) / 32767
     normalized = voiced_audio / np.max(np.abs(voiced_audio))
     amplified = normalized * 0.9
-    return amplified.astype(np.float32)
+    mid_boosted = apply_midrange_enhancement(amplified, sample_rate)
+    return mid_boosted.astype(np.float32)


### PR DESCRIPTION
## Summary
- boost mid-range frequencies during audio enhancement
- extract and store per-speaker embeddings and log summary CSV

## Testing
- `python -m py_compile Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/vad_enhancer.py Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/live_zoom_record_and_analyze.py`
- `python Mute-Voce-main/LiveVoiceAutoZoom/LiveVoiceAutoZoom/scripts/live_zoom_record_and_analyze.py --help` *(fails: IndentationError in recorder.py)*

------
https://chatgpt.com/codex/tasks/task_e_689e1f3d07408320b05305e851713bf2